### PR TITLE
yfinance APIレート制限問題を解決

### DIFF
--- a/bin/update.sh
+++ b/bin/update.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# 使用方法を表示する関数
+usage() {
+    echo "使用方法: $0 [銘柄コード1,銘柄コード2,...] [--period 期間]"
+    echo "例: $0 8058,9984 --period 30d"
+    echo "引数なしで実行すると、GASから銘柄リストを取得します"
+    exit 1
+}
+
+# 引数があれば、そのまま price_updater.py に渡す
+if [ $# -eq 0 ]; then
+    # 引数がない場合は、引数なしで実行
+    echo "GASから銘柄リストを取得して実行します..."
+    python src/python/price_updater.py
+else
+    # 引数がある場合は、そのまま渡す
+    python src/python/price_updater.py "$@"
+fi

--- a/bin/update.sh
+++ b/bin/update.sh
@@ -2,17 +2,18 @@
 
 # 使用方法を表示する関数
 usage() {
-    echo "使用方法: $0 [銘柄コード1,銘柄コード2,...] [--period 期間]"
-    echo "例: $0 8058,9984 --period 30d"
+    echo "使用方法: $0 [銘柄コード1,銘柄コード2,...] [--period 期間] [--batch-size バッチサイズ]"
+    echo "例: $0 8058,9984 --period 30d --batch-size 5"
     echo "引数なしで実行すると、GASから銘柄リストを取得します"
+    echo "バッチサイズを小さくするとレート制限回避に効果的です"
     exit 1
 }
 
 # 引数があれば、そのまま price_updater.py に渡す
 if [ $# -eq 0 ]; then
-    # 引数がない場合は、引数なしで実行
-    echo "GASから銘柄リストを取得して実行します..."
-    python src/python/price_updater.py
+    # 引数がない場合は、バッチサイズ5で実行
+    echo "GASから銘柄リストを取得して実行します（バッチサイズ: 3）..."
+    python src/python/price_updater.py --batch-size 3
 else
     # 引数がある場合は、そのまま渡す
     python src/python/price_updater.py "$@"

--- a/src/python/price_updater.py
+++ b/src/python/price_updater.py
@@ -152,6 +152,7 @@ def fetch_tickers_from_gas(gas_url: str) -> List[str]:
     GASから銘柄リストを取得する関数（リトライロジック付き）
     """
     try:
+        logger.info(f"GASから銘柄リストの取得を開始します: {gas_url}")
         response = requests.get(gas_url)
         response.raise_for_status()
         tickers = json.loads(response.text)


### PR DESCRIPTION
## Summary
- yfinance APIの厳格化されたレート制限により108銘柄取得時にエラーが発生する問題を解決
- リトライ機能強化、待機時間改善、バッチ処理システム追加により安定したデータ取得を実現

## 主な変更点
- **リトライ機能強化**: 3回→5回、10-60秒の指数バックオフ
- **待機時間改善**: 固定0.5秒→ランダム5-10秒
- **バッチ処理システム追加**: デフォルト5銘柄、バッチ間30-60秒待機
- **レート制限エラー検出**: 30-60秒の追加待機
- **--batch-sizeオプション追加**: カスタマイズ可能
- **エラーハンドリング強化**: 詳細なログ出力

## Test plan
- [x] 2銘柄での動作確認済み
- [x] バッチ処理機能の動作確認済み
- [x] レート制限エラーハンドリングの動作確認済み
- [x] シェルスクリプトの構文修正済み

🤖 Generated with [Claude Code](https://claude.ai/code)